### PR TITLE
[RESPONSIVE REFRESH] Re-init swiper if breakpoint change

### DIFF
--- a/src/wwElement.vue
+++ b/src/wwElement.vue
@@ -193,6 +193,9 @@ export default {
                 '--timing-function': this.content.linearTransition ? 'linear' : 'auto',
             };
         },
+        currentScreenSize() {
+            return wwLib.globalContext.browser.breakpoint;
+        },
     },
     watch: {
         /* wwEditor:start */
@@ -220,6 +223,9 @@ export default {
         /* wwEditor:end */
         'content.mainLayoutContent'() {
             this.initSwiper(true);
+        },
+        currentScreenSize() {
+            this.initSwiper();
         },
     },
     mounted() {


### PR DESCRIPTION
The swiper create some elements copies that are not refreshed if style change during resizing, so re-init in this case