### PR TITLE
[WW-5274] Fix BNP dependency vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "3.1.1",
             "license": "MIT",
             "dependencies": {
-                "swiper": "7.3.1"
+                "swiper": "12.1.4"
             },
             "devDependencies": {
                 "@vue/eslint-config-prettier": "^6.0.0",
@@ -2503,14 +2503,6 @@
             },
             "engines": {
                 "node": ">=6.0.0"
-            }
-        },
-        "node_modules/dom7": {
-            "version": "4.0.6",
-            "resolved": "https://registry.npmjs.org/dom7/-/dom7-4.0.6.tgz",
-            "integrity": "sha512-emjdpPLhpNubapLFdjNL9tP06Sr+GZkrIHEXLWvOGsytACUrkbeIdjO5g77m00BrHTznnlcNqgmn7pCN192TBA==",
-            "dependencies": {
-                "ssr-window": "^4.0.0"
             }
         },
         "node_modules/ee-first": {
@@ -6952,11 +6944,6 @@
             "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
             "dev": true
         },
-        "node_modules/ssr-window": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/ssr-window/-/ssr-window-4.0.2.tgz",
-            "integrity": "sha512-ISv/Ch+ig7SOtw7G2+qkwfVASzazUnvlDTwypdLoPoySv+6MqlOV10VwPSE6EWkGjhW50lUmghPmpYZXMu/+AQ=="
-        },
         "node_modules/ssri": {
             "version": "9.0.1",
             "resolved": "https://registry.npmjs.org/ssri/-/ssri-9.0.1.tgz",
@@ -7141,24 +7128,20 @@
             }
         },
         "node_modules/swiper": {
-            "version": "7.3.1",
-            "resolved": "https://registry.npmjs.org/swiper/-/swiper-7.3.1.tgz",
-            "integrity": "sha512-YHa8uI22UwF9Q6F9tCDSai7/BJo8uVHKampKYAIShlFrWoHfM+sCCn24Yeq3oqIKZv2bfSULzXKsXmh0VpCNeQ==",
+            "version": "12.1.4",
+            "resolved": "https://registry.npmjs.org/swiper/-/swiper-12.1.4.tgz",
+            "integrity": "sha512-bihiwoKMOQwW8FfdUbo1DgkVH25E+4ZELIq0oopL1KTKBteLuaTMi/wwFjMxtlhTkk45k3XQ89D1Fvv0spSqBA==",
             "funding": [
                 {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/swiperjs"
+                    "type": "custom",
+                    "url": "https://sponsors.nolimits4web.com"
                 },
                 {
-                    "type": "open_collective",
-                    "url": "http://opencollective.com/swiper"
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nolimits4web"
                 }
             ],
-            "hasInstallScript": true,
-            "dependencies": {
-                "dom7": "^4.0.1",
-                "ssr-window": "^4.0.1"
-            },
+            "license": "MIT",
             "engines": {
                 "node": ">= 4.7.0"
             }
@@ -10361,14 +10344,6 @@
             "dev": true,
             "requires": {
                 "esutils": "^2.0.2"
-            }
-        },
-        "dom7": {
-            "version": "4.0.6",
-            "resolved": "https://registry.npmjs.org/dom7/-/dom7-4.0.6.tgz",
-            "integrity": "sha512-emjdpPLhpNubapLFdjNL9tP06Sr+GZkrIHEXLWvOGsytACUrkbeIdjO5g77m00BrHTznnlcNqgmn7pCN192TBA==",
-            "requires": {
-                "ssr-window": "^4.0.0"
             }
         },
         "ee-first": {
@@ -13722,11 +13697,6 @@
             "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
             "dev": true
         },
-        "ssr-window": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/ssr-window/-/ssr-window-4.0.2.tgz",
-            "integrity": "sha512-ISv/Ch+ig7SOtw7G2+qkwfVASzazUnvlDTwypdLoPoySv+6MqlOV10VwPSE6EWkGjhW50lUmghPmpYZXMu/+AQ=="
-        },
         "ssri": {
             "version": "9.0.1",
             "resolved": "https://registry.npmjs.org/ssri/-/ssri-9.0.1.tgz",
@@ -13872,13 +13842,9 @@
             "dev": true
         },
         "swiper": {
-            "version": "7.3.1",
-            "resolved": "https://registry.npmjs.org/swiper/-/swiper-7.3.1.tgz",
-            "integrity": "sha512-YHa8uI22UwF9Q6F9tCDSai7/BJo8uVHKampKYAIShlFrWoHfM+sCCn24Yeq3oqIKZv2bfSULzXKsXmh0VpCNeQ==",
-            "requires": {
-                "dom7": "^4.0.1",
-                "ssr-window": "^4.0.1"
-            }
+            "version": "12.1.4",
+            "resolved": "https://registry.npmjs.org/swiper/-/swiper-12.1.4.tgz",
+            "integrity": "sha512-bihiwoKMOQwW8FfdUbo1DgkVH25E+4ZELIq0oopL1KTKBteLuaTMi/wwFjMxtlhTkk45k3XQ89D1Fvv0spSqBA=="
         },
         "table": {
             "version": "6.8.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
     },
     "license": "MIT",
     "dependencies": {
-        "swiper": "7.3.1"
+        "swiper": "12.1.4"
     }
 }

--- a/src/wwElement.vue
+++ b/src/wwElement.vue
@@ -55,7 +55,8 @@
 <script>
 import { nextTick, ref, computed, watch, onMounted, onBeforeUnmount } from 'vue';
 
-import Swiper, { EffectFlip, EffectFade, EffectCoverflow, EffectCube, EffectCards, Autoplay, Mousewheel } from 'swiper';
+import Swiper from 'swiper';
+import { EffectFlip, EffectFade, EffectCoverflow, EffectCube, EffectCards, Autoplay, Mousewheel } from 'swiper/modules';
 import 'swiper/css';
 import 'swiper/css/effect-fade';
 import 'swiper/css/effect-coverflow';


### PR DESCRIPTION
Related WW-5274 PRs:
- weweb-team/weweb-editor https://github.com/weweb-team/weweb-editor/pull/5247
- weweb-team/weweb-back https://github.com/weweb-team/weweb-back/pull/2030
- weweb-team/weweb-dashboard https://github.com/weweb-team/weweb-dashboard/pull/807
- weweb-team/weweb-lambda-back-publisher https://github.com/weweb-team/weweb-lambda-back-publisher/pull/362
- weweb-team/weweb-plugin-figma https://github.com/weweb-team/weweb-plugin-figma/pull/4
- weweb-team/weweb-cron https://github.com/weweb-team/weweb-cron/pull/73
- weweb-team/weweb-lambda-component-builder https://github.com/weweb-team/weweb-lambda-component-builder/pull/16
- weweb-team/weweb-lambda-publisher https://github.com/weweb-team/weweb-lambda-publisher/pull/167
- weweb-team/weweb-plugins https://github.com/weweb-team/weweb-plugins/pull/507
- weweb-team/weweb-preview https://github.com/weweb-team/weweb-preview/pull/442
- weweb-assets/weweb-server https://github.com/weweb-assets/weweb-server/pull/21
- weweb-assets/ww-input-rich-text https://github.com/weweb-assets/ww-input-rich-text/pull/63
- weweb-assets/ww-slider https://github.com/weweb-assets/ww-slider/pull/24
- weweb-assets/ww-slider-images https://github.com/weweb-assets/ww-slider-images/pull/2
- weweb-assets/plugin-xano https://github.com/weweb-assets/plugin-xano/pull/37
